### PR TITLE
Add basic stack navigation with Home and Help screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,25 +1,12 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import RootNavigator from './src/navigation/RootNavigator';
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Hello from POC1 🚀</Text>
+    <NavigationContainer>
+      <RootNavigator />
       <StatusBar style="auto" />
-    </View>
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    fontSize: 32,
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "expo": "~53.0.20",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.5"
+    "react-native": "0.79.5",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "react-native-screens": "^4.0.0",
+    "react-native-safe-area-context": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,0 +1,19 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from '../screens/HomeScreen';
+import HelpScreen from '../screens/HelpScreen';
+
+export type RootStackParamList = {
+  Home: undefined;
+  Help: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="Help" component={HelpScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/screens/HelpScreen.tsx
+++ b/src/screens/HelpScreen.tsx
@@ -1,0 +1,20 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function HelpScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Help Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 24,
+  },
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,20 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Home Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 24,
+  },
+});


### PR DESCRIPTION
## Summary
- integrate React Navigation with a root stack containing Home and Help screens
- add simple HomeScreen and HelpScreen components
- wire NavigationContainer and RootNavigator in App

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find module '@react-navigation/native' or its type declarations)*


------
https://chatgpt.com/codex/tasks/task_e_6897b626f68c832fb37915f677536397