### PR TITLE
Add help navigation button on home screen

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,9 +1,14 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Button } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/RootNavigator';
 
-export default function HomeScreen() {
+type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
+
+export default function HomeScreen({ navigation }: Props) {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Home Screen</Text>
+      <Button title="Go to Help" onPress={() => navigation.navigate('Help')} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add centered "Go to Help" button on Home screen

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6897ba0c6944832f9b29d3f2d42e35c2