### PR TITLE
Add mock LLM service and prompt UI on home screen

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,13 +1,31 @@
-import { StyleSheet, Text, View, Button } from 'react-native';
+import { useState } from 'react';
+import { StyleSheet, Text, View, Button, TextInput } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/RootNavigator';
+import { getLLM } from '../services/llm/MockLLMService';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: Props) {
+  const [prompt, setPrompt] = useState('');
+  const [answer, setAnswer] = useState('');
+
+  const handleAsk = async () => {
+    const result = await getLLM().chat(prompt);
+    setAnswer(result);
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Home Screen</Text>
+      <TextInput
+        style={styles.input}
+        value={prompt}
+        onChangeText={setPrompt}
+        placeholder="Type a prompt"
+      />
+      <Button title="Ask" onPress={handleAsk} />
+      {answer ? <Text style={styles.response}>{answer}</Text> : null}
       <Button title="Go to Help" onPress={() => navigation.navigate('Help')} />
     </View>
   );
@@ -21,5 +39,16 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 24,
+  },
+  input: {
+    width: '80%',
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginVertical: 10,
+  },
+  response: {
+    marginVertical: 10,
+    textAlign: 'center',
   },
 });

--- a/src/services/llm/MockLLMService.ts
+++ b/src/services/llm/MockLLMService.ts
@@ -1,0 +1,18 @@
+export interface LLMService {
+  chat(prompt: string): Promise<string>;
+}
+
+export class MockLLMService implements LLMService {
+  async chat(prompt: string): Promise<string> {
+    return Promise.resolve('This is a mock response.');
+  }
+}
+
+let instance: LLMService | null = null;
+
+export function getLLM(): LLMService {
+  if (!instance) {
+    instance = new MockLLMService();
+  }
+  return instance;
+}


### PR DESCRIPTION
## Summary
- add MockLLMService interface, implementation, and singleton getter
- allow HomeScreen to send prompt to mock LLM and display response

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897bba293b8832f9cfce33ad9901a4c