### PR TITLE
Add ThemedText component for screen titles

### DIFF
--- a/src/components/ThemedText.tsx
+++ b/src/components/ThemedText.tsx
@@ -1,0 +1,22 @@
+import { Text, StyleSheet, TextProps } from 'react-native';
+import { ReactNode } from 'react';
+
+export type ThemedTextProps = TextProps & {
+  children: ReactNode;
+};
+
+export default function ThemedText({ style, children, ...rest }: ThemedTextProps) {
+  return (
+    <Text style={[styles.text, style]} {...rest}>
+      {children}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  text: {
+    fontSize: 24,
+    color: '#000',
+  },
+});
+

--- a/src/screens/HelpScreen.tsx
+++ b/src/screens/HelpScreen.tsx
@@ -1,9 +1,10 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import ThemedText from '../components/ThemedText';
 
 export default function HelpScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Help Screen</Text>
+      <ThemedText>Help Screen</ThemedText>
     </View>
   );
 }
@@ -13,8 +14,5 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  text: {
-    fontSize: 24,
   },
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View, Button, TextInput } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/RootNavigator';
 import { getLLM } from '../services/llm/MockLLMService';
+import ThemedText from '../components/ThemedText';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
@@ -17,7 +18,7 @@ export default function HomeScreen({ navigation }: Props) {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Home Screen</Text>
+      <ThemedText>Home Screen</ThemedText>
       <TextInput
         style={styles.input}
         value={prompt}
@@ -36,9 +37,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  text: {
-    fontSize: 24,
   },
   input: {
     width: '80%',


### PR DESCRIPTION
## Summary
- create ThemedText wrapper component with default font size and color
- use ThemedText for titles on Home and Help screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6897bd287cd8832f9f9bf6bea853d1b9