### PR TITLE
Add Jest testing setup

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-native/extend-expect";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^7.1.17",
@@ -22,7 +23,15 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "jest-expo": "^53.0.0",
+    "@testing-library/react-native": "^12.5.3",
+    "@testing-library/jest-native": "^5.4.4",
+    "@types/jest": "^29.5.11"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "setupFilesAfterEnv": ["<rootDir>/jest-setup.ts"]
   },
   "private": true
 }

--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { NavigationContainer } from "@react-navigation/native";
+import HomeScreen from "../HomeScreen";
+
+describe("HomeScreen", () => {
+  it("renders title", () => {
+    const navigation: any = { navigate: jest.fn() };
+    const route: any = { key: "Home", name: "Home" };
+    const { getByText } = render(
+      <NavigationContainer>
+        <HomeScreen navigation={navigation} route={route} />
+      </NavigationContainer>
+    );
+    expect(getByText("Home Screen")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest for Expo with testing libraries
- add jest setup file and HomeScreen test

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897bf5b1d90832fbda28b3b62317cb7