### PR TITLE
feat: prevent keyboard from covering input

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,15 @@
-import { useState } from 'react';
-import { StyleSheet, View, Button, TextInput, ScrollView } from 'react-native';
+import { useRef, useState } from 'react';
+import {
+  StyleSheet,
+  View,
+  Button,
+  TextInput,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  Keyboard,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/RootNavigator';
 import { getLLM } from '../services/llm/MockLLMService';
@@ -10,47 +20,64 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 export default function HomeScreen({ navigation }: Props) {
   const [prompt, setPrompt] = useState('');
   const [history, setHistory] = useState<{ question: string; answer: string }[]>([]);
+  const scrollViewRef = useRef<ScrollView>(null);
+  const insets = useSafeAreaInsets();
 
   const handleAsk = async () => {
     if (!prompt.trim()) return;
     const result = await getLLM().chat(prompt);
     setHistory((prev) => [...prev, { question: prompt, answer: result }]);
     setPrompt('');
+    Keyboard.dismiss();
   };
 
   return (
-    <View style={styles.container}>
-      <ScrollView style={styles.history} contentContainerStyle={styles.historyContent}>
-        {history.map((item, index) => (
-          <View key={index} style={styles.entry}>
-            <ThemedText style={styles.question}>{item.question}</ThemedText>
-            <ThemedText style={styles.answer}>{item.answer}</ThemedText>
-          </View>
-        ))}
-      </ScrollView>
-      <TextInput
-        style={styles.input}
-        value={prompt}
-        onChangeText={setPrompt}
-        placeholder="Type a prompt"
-      />
-      <Button title="Ask" onPress={handleAsk} />
-      <Button title="Go to Help" onPress={() => navigation.navigate('Help')} />
-    </View>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <View style={styles.container}>
+        <ScrollView
+          ref={scrollViewRef}
+          style={styles.history}
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ padding: 16, paddingBottom: 24 }}
+          onContentSizeChange={() =>
+            scrollViewRef.current?.scrollToEnd({ animated: true })
+          }
+        >
+          {history.map((item, index) => (
+            <View key={index} style={styles.entry}>
+              <ThemedText style={styles.question}>{item.question}</ThemedText>
+              <ThemedText style={styles.answer}>{item.answer}</ThemedText>
+            </View>
+          ))}
+        </ScrollView>
+        <Button title="Go to Help" onPress={() => navigation.navigate('Help')} />
+        <View style={{ padding: 16 }}>
+          <TextInput
+            style={styles.input}
+            value={prompt}
+            onChangeText={setPrompt}
+            placeholder="Type a prompt"
+            returnKeyType="send"
+            blurOnSubmit={false}
+            onSubmitEditing={handleAsk}
+          />
+          <Button title="Ask" onPress={handleAsk} />
+        </View>
+        <View style={{ height: insets.bottom + 16 }} />
+      </View>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 20,
   },
   history: {
     flex: 1,
-    marginBottom: 10,
-  },
-  historyContent: {
-    paddingBottom: 10,
   },
   entry: {
     marginBottom: 10,
@@ -66,6 +93,5 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 8,
-    marginBottom: 10,
   },
 });


### PR DESCRIPTION
## Summary
- keep input visible with KeyboardAvoidingView and safe-area spacer
- scroll to latest message and send via return key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c67a519c832fa574b365cd3ca868