### PR TITLE
chore: add global eslint ignores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,8 @@ const compat = new FlatCompat({
 });
 
 export default [
+  { ignores: ['node_modules/', 'dist/', 'build/', 'coverage/', '.expo/'] },
+
   // Flat-ready configs
   js.configs.recommended,
   ...ts.configs.recommended,
@@ -50,6 +52,5 @@ export default [
       // keep imports tidy (auto-fixable)
       'import/order': ['warn', { 'newlines-between': 'always', alphabetize: { order: 'asc' } }],
     },
-    ignores: ['node_modules/', 'dist/', 'build/'],
   },
 ];


### PR DESCRIPTION
## Summary
- ensure ESLint ignores build artifacts like node_modules, dist, build, coverage, and .expo

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6897d063d364832fa4a3916e4398b8d3