### PR TITLE
feat: stream LLM responses

### DIFF
--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import HomeScreen from '../HomeScreen';
 
 describe('HomeScreen', () => {
-  it('renders title', () => {
+  it('renders Ask button', () => {
     const navigation: any = { navigate: jest.fn() };
     const route: any = { key: 'Home', name: 'Home' };
     const { getByText } = render(
@@ -13,6 +13,6 @@ describe('HomeScreen', () => {
         <HomeScreen navigation={navigation} route={route} />
       </NavigationContainer>,
     );
-    expect(getByText('Home Screen')).toBeTruthy();
+    expect(getByText('Ask')).toBeTruthy();
   });
 });

--- a/src/services/llm/MockLLMService.ts
+++ b/src/services/llm/MockLLMService.ts
@@ -1,10 +1,32 @@
 export interface LLMService {
-  chat(prompt: string): Promise<string>;
+  chat(
+    prompt: string,
+    options?: {
+      signal?: AbortSignal;
+    },
+  ): AsyncIterable<string>;
 }
 
 export class MockLLMService implements LLMService {
-  async chat(prompt: string): Promise<string> {
-    return Promise.resolve('This is a mock response.');
+  async *chat(prompt: string, { signal }: { signal?: AbortSignal } = {}): AsyncGenerator<string> {
+    const tokens = 'This is a mock response.'.split(' ');
+    for (const token of tokens) {
+      await new Promise<void>((resolve) => {
+        const id = setTimeout(resolve, 50);
+        signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(id);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+      if (signal?.aborted) {
+        break;
+      }
+      yield token + ' ';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- stream tokens on Home screen with ability to stop mid-response
- add AbortController-style cancellation to LLM service
- simulate streaming from mock LLM by yielding tokens with delays

## Testing
- `npm test` *(fails: Skipping tests: dev dependencies not installed in this environment.)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6897db237a60832fb1431a3e418857ad